### PR TITLE
Improved support for gvim/sessionman

### DIFF
--- a/plugin/localvimrc.vim
+++ b/plugin/localvimrc.vim
@@ -90,5 +90,8 @@ endf
 
 augroup LOCAL_VIMRC
   autocmd BufWritePost * if index(s:c.names, expand('%:t')) >= 0 | call LVRWithCache('LVRUpdateCache', [] ) | endif
-  autocmd BufNewFile,BufRead * call LVRCwdCache()
+  " Only activate if autochdir is not set
+  if ! &autochdir 
+    autocmd BufNewFile,BufRead * call LVRCwdCache()
+  endif
 augroup end


### PR DESCRIPTION
Added LVRCwdCache function and BufNewFile/BufRead autocommand for it.

This modification lets the user to switch projects by changing directory and opening a file, which is good for gvim/sessionman users since normally they wont start vim in the project working directory.

The new autocommand is only set if the 'autochdir' option isnt set.
