### PR TITLE
Fix vim addon local vimrc for opening directories

### DIFF
--- a/plugin/localvimrc.vim
+++ b/plugin/localvimrc.vim
@@ -75,8 +75,6 @@ command! SourceLocalVimrcOnce
     \ | call LVRWithCache('LVRRecurseUp', [getcwd(), s:c.names] )
     \ | endif
 
-SourceLocalVimrcOnce
-
 " if its you writing a file update hash automatically
 fun! LVRUpdateCache(cache)
   let f = expand('%:p')
@@ -93,6 +91,6 @@ augroup LOCAL_VIMRC
   " directory - so this is only an approximation to what people might expect.
   " Idle events and the like would be an alternative
   if ! &autochdir
-    autocmd BufNewFile,BufRead * SourceLocalVimrcOnce
+    autocmd VimEnter,BufNewFile,BufRead * SourceLocalVimrcOnce
   endif
 augroup end


### PR DESCRIPTION
Hi Marc, I came across another one of your useful plugins, thanks.  

Here's a small patch:  My local vimrc was not getting loaded if I opened a directory with vim.  I'm now triggering the local vimrc lookup to occur after VimEnter, rather than at script load time, and that seems to fix it.

This commit calls SourceLocalVimrcOnce from the VimEnter
event, enabling localvimrc's to be loaded even if vim is
just opening a directory.
