### PR TITLE
Fixed vimrc search when dir containsed spaces

### DIFF
--- a/plugin/localvimrc.vim
+++ b/plugin/localvimrc.vim
@@ -64,7 +64,7 @@ fun! LVRRecurseUp(cache, dir, names)
       " The alternative fix would be calling SourceLocalVimrcOnce
       " at VimEnter, however I feel that you cannot setup additional VimEnter
       " commands then - thus preferring getcwd()
-      let f = findfile(n, getcwd().";", nr)
+      let f = findfile(n, escape(getcwd(), "\ ").";", nr)
       if f == '' | break | endif
       call add(files, fnamemodify(f,':p'))
       let nr += 1


### PR DESCRIPTION
- getcwd() needs to be escaped before being fed to
  findfile()

Signed-off-by: Camille Moncelier moncelier@devlife.org
