### PR TITLE
4 choices; YONV variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,25 @@ Features:
 - When Vim starts up, every directory from root to the directory of the file
   is traversed and special files such as .(local-)vimrc files are sourced
 
-- Because you don't want to run untrusted code by accident, this plugin
-  calculates a asks you before sourcing any given file, and optionally
-  remembers your answer for the future.  Possible answers are (with the
-  abbreviation captitalized):
+- Because you don't want to run untrusted code by accident, this plugin asks
+  you before sourcing any given file.  Your answer can optionally be "sticky",
+  i.e. saved for use in the future.  The possible answers (the abbreviation
+  is captitalized) are:
 
-    -  *Yes*: Read the file from now on, without asking
+    Answer | Read now? | Sticky?
+    :-----:|:---------:|:------:
+    Yes    | Yes       | Yes
+    Once   | Yes       | No
+    No     | No        | No
+    neVer  | No        | Yes
 
-    - `*Once*: Read the file this time, but ask again next time
+- The plugin also stores a hash of the file's contents; if the file changes,
+  you'll be asked again, i.e. any sticky answer you gave previously will be
+  ignored
 
-    - `*No*: Don't read it this time, but ask again next time
-
-    - `*neVer*: Don't read it, now or ever
-  
-- It also remembers a hash of the file's contents, so that if the file
-  changes, you'll be asked again.
-
-  If you use vim to edit a local vimrc file, an answer of "Always" is
-  automatically saved for (that version of) the file, on the theory
-  that you trust any edits you yourself have made.
+- If you use vim to edit a local vimrc file, a sticky "yes" is automatically
+  saved for (that version of) the file, on the assumption that you trust any
+  edits you yourself have made
 
 - if you change a directory and edit a file the local vimrc files are resourced
 
@@ -72,3 +72,4 @@ unless the file belongs to a different owner..
 contributors
 ============
 Thiago de Arruda (github.com/tarruba)
+Eric Siegerman (github.com/esiegerman)

--- a/plugin/localvimrc.vim
+++ b/plugin/localvimrc.vim
@@ -10,25 +10,14 @@ let s:c.hash_fun = get(s:c,'hash_fun','LVRHashOfFile')
 let s:c.cache_file = get(s:c,'cache_file', $HOME.'/.vim_local_rc_cache')
 let s:c.resource_on_cwd_change = get(s:c, 'resource_on_cwd_change', 1)
 let s:last_cwd = ''
-let s:cache_format_version=2		" Increment this on any format change
+let s:cache_format_version=2            " Increment this on any format change
 
-"            read     ask again
-" Value      file     next time [1]
-" -----      ----     -------------
-" ANS_YES    yes         no
-" ANS_ONCE   yes         yes
-" ANS_NO     no          yes
-" ANS_NEVER  no          no
-" ANS_ASK[2] (n/a)       yes
+" Map return values from confirm() into our answer codes.
+" If confirm() can't provide a good answer, it returns 0; hence we set
+" [0] to a safe default.
 "
-" [1] Yes: the next time this file is a candidate to be run, the user
-"          will be asked again whether to actually run it
-"     No:  User's answer will be cached, and applied automatically in
-"          future (until the file's hash changes)
-"
-" [2] ANS_ASK is used internally; it doesn't correspond directly to
-"     any one of the options offered to the user
-
+" Besides these, there's also ANS_ASK, which is only used internally;
+" it's written to the cache if the user gives a non-sticky answer.
 let s:answer_map = ['ANS_NO', 'ANS_YES', 'ANS_ONCE', 'ANS_NO', 'ANS_NEVER']
 
 " very simple hash function using md5 falling back to VimL implementation
@@ -97,9 +86,9 @@ fun! LVRWithCache(F, args)
   let c = copy(cache)
   " if the cache isn't in the format we understand, just blow it away;
   " it's not valuable enough to be worth converting.
-  " note that we do this whether the file's version is too low or too high;
+  " note that we do this whether the file's version is too low *or* too high;
   " in either case, we assume that we don't know how to interpret the contents.
-  let ver = get(cache, 'format_version', -1)	" default should never match any real version number
+  let ver = get(cache, 'format_version', -1)    " default should never match any real version number
   if ver != s:cache_format_version
     let cache = {'seed' : localtime(), 'format_version' : s:cache_format_version}
   endif


### PR DESCRIPTION
I've just started using local_vimrc.  It rocks!

Here's an enhancement.  The answers it accepts to its prompt are asymmetrical.  Only _yes_ is "sticky"; if you say _no_, it asks you again the next time, and the next, ....

Basically, there are two independent questions encompassed by that prompt:
- Read the file this time?
- Remember the answer for next time?

yielding, of course, four possible combinations, of which only two are implemented.

This branch implements the other two.

I actually came up with two variants.  Implementations are identical; it's just the names for the choices offered to the user that are different.

One variant, which I'll refer to as **YONV** for obvious reasons, gives the user these options:
- _Yes_: read the file; sticky
- _Once_: read the file; not sticky
- _No_: don't read the file; not sticky
- _neVer_: don't read the file; sticky

That's what's in this PR.

The other variant, **YNAV**, is:
- _Yes_: read the file; not sticky
- _No_: don't read the file; not sticky
- _Always_: read the file; sticky
- _neVer_: don't read the file; sticky

The advantages of YNAV are that _yes_ and _no_ "match", in that neither one is sticky; and the words _always_ and _never_ have nicely matching sticky meanings to go with the sticky choices they represent.  The down side is that _yes_ becomes non-sticky, which isn't backward compatible.

YONV _is_ backward compatible; it preserves the current meanings of both _yes_ and _no_.  Plus, I kind of like _once_ as the name for its option.  But _yes_ and _no_ remain asymmetrical -- one sticky, one not -- which goes against the grain for me.

In the end, I can't decide which I prefer.  So I'm offering you both choices ... um, meta-choices I guess :-)  Assuming you like this idea at all, please pick one of the PRs to review, and just close the other one.  And speaking of review, this is my first attempt at nontrivial VimL, so please review it especially carefully.

Thanks.
- Eric
