### PR TITLE
(RFC) add feature to overwrite default vim addons

### DIFF
--- a/plugin/localvimrc.vim
+++ b/plugin/localvimrc.vim
@@ -5,6 +5,7 @@ if !exists('g:local_vimrc') | let g:local_vimrc = {} | endif | let s:c = g:local
 " configuration files. They rarely differ in name.
 " Users will instantly understand what it does.
 let s:c.names = get(s:c, 'names', ['.vimrc'])
+let s:c.overwriter_names = get(s:c, 'overwriter_names', ['.overwrite.vimrc'])
 
 let s:c.hash_fun = get(s:c,'hash_fun','LVRHashOfFile')
 let s:c.cache_file = get(s:c,'cache_file', $HOME.'/.vim_local_rc_cache')
@@ -105,4 +106,6 @@ augroup LOCAL_VIMRC
   if ! &autochdir
     autocmd BufNewFile,BufRead * SourceLocalVimrcOnce
   endif
+
+  autocmd VimEnter,BufNewFile,BufRead * call LVRWithCache('LVRRecurseUp', [getcwd(), s:c.overwriter_names] )
 augroup end


### PR DESCRIPTION
Problem
=

Suppose you have a `.vim/ftplugin/some_language.vim` is like this:

```viml
...

let g:some_variable = "foo"

...
```

And you want to overwrite `g:some_variable` with a local `.vimrc`:

```viml
autocmd FileType some_language let g:some_variable = "bar"
```

But this doesn't work because the current local-vimrc `source`-es `.vimrc`s **only on `VimEnter`.
While files in `.vim/ftplugin/` are `source`-ed on **every `BufNewFile,BufReadPost`**.
So it seems that we should have some way to source local `.vimrc`-s after `ftplugin`-s!

Solution
=

I added another configuration called `overwriter_names`, with which we can choose files `source`-ed every time.
I agree that it's also okay to make this plugin to `SourceLocalVimrc` on `BufNewFile,BufReadPost` instead.
But I'm concerned with performance and compatibility.
So please tell me your idea.